### PR TITLE
chore: remove untrusted input from logging

### DIFF
--- a/android/src/main/java/com/horcrux/svg/UseView.java
+++ b/android/src/main/java/com/horcrux/svg/UseView.java
@@ -69,7 +69,7 @@ class UseView extends RenderableView {
 
         if (template == null) {
             FLog.w(ReactConstants.TAG, "`Use` element expected a pre-defined svg template as `href` prop, " +
-                    "template named: " + mHref + " is not defined.");
+                    "template is not defined.");
             return;
         }
 
@@ -110,7 +110,7 @@ class UseView extends RenderableView {
         VirtualView template = getSvgView().getDefinedTemplate(mHref);
         if (template == null) {
             FLog.w(ReactConstants.TAG, "`Use` element expected a pre-defined svg template as `href` prop, " +
-                    "template named: " + mHref + " is not defined.");
+                    "template is not defined.");
             return -1;
         }
 
@@ -127,7 +127,7 @@ class UseView extends RenderableView {
         VirtualView template = getSvgView().getDefinedTemplate(mHref);
         if (template == null) {
             FLog.w(ReactConstants.TAG, "`Use` element expected a pre-defined svg template as `href` prop, " +
-                    "template named: " + mHref + " is not defined.");
+                    "template is not defined.");
             return null;
         }
         Path path = template.getPath(canvas, paint);

--- a/android/src/main/java/com/horcrux/svg/VirtualView.java
+++ b/android/src/main/java/com/horcrux/svg/VirtualView.java
@@ -309,11 +309,11 @@ abstract public class VirtualView extends ReactViewGroup {
                     case CLIP_RULE_NONZERO:
                         break;
                     default:
-                        FLog.w(ReactConstants.TAG, "RNSVG: clipRule: " + mClipRule + " unrecognized");
+                        FLog.w(ReactConstants.TAG, "RNSVG: clipRule unrecognized");
                 }
                 mCachedClipPath = clipPath;
             } else {
-                FLog.w(ReactConstants.TAG, "RNSVG: Undefined clipPath: " + mClipPath);
+                FLog.w(ReactConstants.TAG, "RNSVG: Undefined clipPath");
             }
         }
 


### PR DESCRIPTION
There are a few instances of unsanitized input making into the logging and I don't know where they are consumed, but if they somehow make it into the DOM this could maybe be used as an XSS? I would just get rid of it as precaution..