### PR TITLE
feat: add mask and offset to propWhitelist

### DIFF
--- a/xml.js
+++ b/xml.js
@@ -46,40 +46,121 @@ export const tags = {
   pattern: Pattern,
   mask: Mask,
 };
-Object.setPrototypeOf(tags, null)
+Object.setPrototypeOf(tags, null);
 
 // intentionally excluded href, xlinkHref, style
 const propWhitelist = [
-    'alignmentBaseline', 'alignmentBaseline', 'baselineShift', 'bbHeight',
-    'bbWidth', 'clipPath', 'clipRule', 'cx', 'cy', 'd', 'delayLongPress',
-    'delayPressIn', 'delayPressOut', 'disabled', 'fill', 'fillOpacity',
-    'fillRule', 'fontData', 'fontFamily', 'fontFeatureSettings', 'fontSize',
-    'fontStretch', 'fontStyle', 'fontVariant', 'fontVariantLigatures',
-    'fontVariationSettings', 'fontWeight', 'fx', 'fy', 'gradientTransform',
-    'gradientUnits', 'height', 'id', 'inlineSize', 'kerning', 'letterSpacing',
-    'maskContentUnits', 'maskTransform', 'maskUnits', 'method', 'midLine',
-    'onLayout', 'onLongPress', 'onPress', 'onPressIn', 'onPressOut', 'opacity',
-    'origin', 'originX', 'originY', 'patternContentUnits', 'patternTransform',
-    'patternUnits', 'pointerEvents', 'points', 'preserveAspectRatio', 'r',
-    'rotate', 'rotation', 'rx', 'ry', 'scale', 'scaleX', 'scaleY', 'side',
-    'skew', 'skewX', 'skewY', 'spacing', 'startOffset', 'stopColor',
-    'stopOpacity', 'stroke', 'strokeDasharray', 'strokeDashoffset',
-    'strokeLinecap', 'strokeLinejoin', 'strokeMiterlimit', 'strokeOpacity',
-    'strokeWidth', 'textAnchor', 'textDecoration', 'transform', 'translate',
-    'translateX', 'translateY', 'vectorEffect', 'verticalAlign', 'viewBox',
-    'width', 'wordSpacing', 'x', 'x1', 'x2', 'y', 'y1', 'y2',
-]
+  'alignmentBaseline',
+  'alignmentBaseline',
+  'baselineShift',
+  'bbHeight',
+  'bbWidth',
+  'clipPath',
+  'clipRule',
+  'cx',
+  'cy',
+  'd',
+  'delayLongPress',
+  'delayPressIn',
+  'delayPressOut',
+  'disabled',
+  'fill',
+  'fillOpacity',
+  'fillRule',
+  'fontData',
+  'fontFamily',
+  'fontFeatureSettings',
+  'fontSize',
+  'fontStretch',
+  'fontStyle',
+  'fontVariant',
+  'fontVariantLigatures',
+  'fontVariationSettings',
+  'fontWeight',
+  'fx',
+  'fy',
+  'gradientTransform',
+  'gradientUnits',
+  'height',
+  'id',
+  'inlineSize',
+  'kerning',
+  'letterSpacing',
+  'mask',
+  'maskContentUnits',
+  'maskTransform',
+  'maskUnits',
+  'method',
+  'midLine',
+  'offset',
+  'onLayout',
+  'onLongPress',
+  'onPress',
+  'onPressIn',
+  'onPressOut',
+  'opacity',
+  'origin',
+  'originX',
+  'originY',
+  'patternContentUnits',
+  'patternTransform',
+  'patternUnits',
+  'pointerEvents',
+  'points',
+  'preserveAspectRatio',
+  'r',
+  'rotate',
+  'rotation',
+  'rx',
+  'ry',
+  'scale',
+  'scaleX',
+  'scaleY',
+  'side',
+  'skew',
+  'skewX',
+  'skewY',
+  'spacing',
+  'startOffset',
+  'stopColor',
+  'stopOpacity',
+  'stroke',
+  'strokeDasharray',
+  'strokeDashoffset',
+  'strokeLinecap',
+  'strokeLinejoin',
+  'strokeMiterlimit',
+  'strokeOpacity',
+  'strokeWidth',
+  'textAnchor',
+  'textDecoration',
+  'transform',
+  'translate',
+  'translateX',
+  'translateY',
+  'vectorEffect',
+  'verticalAlign',
+  'viewBox',
+  'width',
+  'wordSpacing',
+  'x',
+  'x1',
+  'x2',
+  'y',
+  'y1',
+  'y2',
+];
 
 function sanitizeProps(props) {
-    const sanitized = {}
-    Object.keys(props).forEach(prop => {
-        if (propWhitelist.includes(prop)) {
-            sanitized[prop] = props[prop]
-        } else {
-            console.log('ignoring unknown prop:', prop)
-        }
-    })
-    return sanitized
+  const sanitized = {};
+  Object.keys(props).forEach(prop => {
+    if (propWhitelist.includes(prop)) {
+      sanitized[prop] = props[prop];
+    } else {
+      console.log('ignoring unknown prop:', prop);
+    }
+  });
+  return sanitized;
 }
 
 function missingTag() {
@@ -318,7 +399,7 @@ export function parse(source) {
     const tag = getName();
     const props = Object.create(null);
     if (!tags[tag]) {
-        throw new Error(`Unknown tag: ${tag}`)
+      throw new Error(`Unknown tag: ${tag}`);
     }
     const element = {
       tag,

--- a/xml.js
+++ b/xml.js
@@ -46,121 +46,40 @@ export const tags = {
   pattern: Pattern,
   mask: Mask,
 };
-Object.setPrototypeOf(tags, null);
+Object.setPrototypeOf(tags, null)
 
 // intentionally excluded href, xlinkHref, style
 const propWhitelist = [
-  'alignmentBaseline',
-  'alignmentBaseline',
-  'baselineShift',
-  'bbHeight',
-  'bbWidth',
-  'clipPath',
-  'clipRule',
-  'cx',
-  'cy',
-  'd',
-  'delayLongPress',
-  'delayPressIn',
-  'delayPressOut',
-  'disabled',
-  'fill',
-  'fillOpacity',
-  'fillRule',
-  'fontData',
-  'fontFamily',
-  'fontFeatureSettings',
-  'fontSize',
-  'fontStretch',
-  'fontStyle',
-  'fontVariant',
-  'fontVariantLigatures',
-  'fontVariationSettings',
-  'fontWeight',
-  'fx',
-  'fy',
-  'gradientTransform',
-  'gradientUnits',
-  'height',
-  'id',
-  'inlineSize',
-  'kerning',
-  'letterSpacing',
-  'mask',
-  'maskContentUnits',
-  'maskTransform',
-  'maskUnits',
-  'method',
-  'midLine',
-  'offset',
-  'onLayout',
-  'onLongPress',
-  'onPress',
-  'onPressIn',
-  'onPressOut',
-  'opacity',
-  'origin',
-  'originX',
-  'originY',
-  'patternContentUnits',
-  'patternTransform',
-  'patternUnits',
-  'pointerEvents',
-  'points',
-  'preserveAspectRatio',
-  'r',
-  'rotate',
-  'rotation',
-  'rx',
-  'ry',
-  'scale',
-  'scaleX',
-  'scaleY',
-  'side',
-  'skew',
-  'skewX',
-  'skewY',
-  'spacing',
-  'startOffset',
-  'stopColor',
-  'stopOpacity',
-  'stroke',
-  'strokeDasharray',
-  'strokeDashoffset',
-  'strokeLinecap',
-  'strokeLinejoin',
-  'strokeMiterlimit',
-  'strokeOpacity',
-  'strokeWidth',
-  'textAnchor',
-  'textDecoration',
-  'transform',
-  'translate',
-  'translateX',
-  'translateY',
-  'vectorEffect',
-  'verticalAlign',
-  'viewBox',
-  'width',
-  'wordSpacing',
-  'x',
-  'x1',
-  'x2',
-  'y',
-  'y1',
-  'y2',
-];
+    'alignmentBaseline', 'alignmentBaseline', 'baselineShift', 'bbHeight',
+    'bbWidth', 'clipPath', 'clipRule', 'cx', 'cy', 'd', 'delayLongPress',
+    'delayPressIn', 'delayPressOut', 'disabled', 'fill', 'fillOpacity',
+    'fillRule', 'fontData', 'fontFamily', 'fontFeatureSettings', 'fontSize',
+    'fontStretch', 'fontStyle', 'fontVariant', 'fontVariantLigatures',
+    'fontVariationSettings', 'fontWeight', 'fx', 'fy', 'gradientTransform',
+    'gradientUnits', 'height', 'id', 'inlineSize', 'kerning', 'letterSpacing',
+    'maskContentUnits', 'maskTransform', 'maskUnits', 'method', 'midLine',
+    'onLayout', 'onLongPress', 'onPress', 'onPressIn', 'onPressOut', 'opacity',
+    'origin', 'originX', 'originY', 'patternContentUnits', 'patternTransform',
+    'patternUnits', 'pointerEvents', 'points', 'preserveAspectRatio', 'r',
+    'rotate', 'rotation', 'rx', 'ry', 'scale', 'scaleX', 'scaleY', 'side',
+    'skew', 'skewX', 'skewY', 'spacing', 'startOffset', 'stopColor',
+    'stopOpacity', 'stroke', 'strokeDasharray', 'strokeDashoffset',
+    'strokeLinecap', 'strokeLinejoin', 'strokeMiterlimit', 'strokeOpacity',
+    'strokeWidth', 'textAnchor', 'textDecoration', 'transform', 'translate',
+    'translateX', 'translateY', 'vectorEffect', 'verticalAlign', 'viewBox',
+    'width', 'wordSpacing', 'x', 'x1', 'x2', 'y', 'y1', 'y2',
+]
 
 function sanitizeProps(props) {
-  const sanitized = {};
-  Object.keys(props).forEach(prop => {
-    if (propWhitelist.includes(prop)) {
-      sanitized[prop] = props[prop];
-    } else {
-      console.log('ignoring unknown prop:', prop);
-    }
-  });
-  return sanitized;
+    const sanitized = {}
+    Object.keys(props).forEach(prop => {
+        if (propWhitelist.includes(prop)) {
+            sanitized[prop] = props[prop]
+        } else {
+            console.log('ignoring unknown prop:', prop)
+        }
+    })
+    return sanitized
 }
 
 function missingTag() {
@@ -399,7 +318,7 @@ export function parse(source) {
     const tag = getName();
     const props = Object.create(null);
     if (!tags[tag]) {
-      throw new Error(`Unknown tag: ${tag}`);
+        throw new Error(`Unknown tag: ${tag}`)
     }
     const element = {
       tag,


### PR DESCRIPTION
# Summary
- Add `mask` and `offset` to propWhitelist to allow SVGs with theses props
- format code according to rest of the project

This can be enough at list for now, to try to avoid update RNSVG library to v12.

## Test Plan
you can test if these SVGs renders correctly (offset prop):
```js
xml =
  '<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg"><defs><linearGradient x1="0%" y1="21.958%" x2="100%" y2="79.18%" id="a"><stop stop-color="#29CCC4" offset="0%"/><stop stop-color="#167D82" offset="100%"/></linearGradient></defs><g fill-rule="nonzero" fill="none"><path d="M22 1.155l13.32 7.69a4 4 0 012 3.464v15.382a4 4 0 01-2 3.464L22 38.845a4 4 0 01-4 0l-13.32-7.69a4 4 0 01-2-3.464V12.309a4 4 0 012-3.464L18 1.155a4 4 0 014 0z" fill="url(#a)"/><g fill="#FFF"><path d="M24.31 19.61l-7.703 3.787 7.702 3.654v2.945l-11.22-5.32-.006-2.901 7.806-3.838-7.8-3.697v-2.945l11.22 5.32z"/><path opacity=".3" d="M13.09 11.295l2.965-1.203 11.22 5.32-2.966 1.203z"/><path opacity=".5" d="M24.31 19.61l2.965-1.203v-2.995l-2.966 1.203zM24.31 27.05v-5.887l2.965-1.363v8.993l-2.966 1.203z"/></g></g></svg>';

xmlRNDR =
  '<svg width="40" height="40" fill="none" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M22 1.155l13.32 7.69a4 4 0 012 3.464v15.382a4 4 0 01-2 3.464L22 38.845a4 4 0 01-4 0l-13.32-7.69a4 4 0 01-2-3.464V12.309a4 4 0 012-3.464L18 1.155a4 4 0 014 0z" fill="url(#paint0_linear_320_704)"/><path fill-rule="evenodd" clip-rule="evenodd" d="M20 11a9 9 0 11-7.143 3.525 1.482 1.482 0 11.46.35A8.422 8.422 0 1020 11.577V11zm4.341 9.106a4.235 4.235 0 11-8.47 0 4.235 4.235 0 018.47 0zm-10.376-5.615a.95.95 0 110-1.901.95.95 0 010 1.901z" fill="#fff"/><defs><linearGradient id="paint0_linear_320_704" x1="38" y1="37.5" x2=".537" y2="6.714" gradientUnits="userSpaceOnUse"><stop stop-color="#E62249"/><stop offset="1" stop-color="#FA3960"/></linearGradient></defs></svg>';
  
render() {
  return (
    <View style={styles.container}>
      <SvgXml xml={this.xml} />
      <SvgXml xml={this.xmlRNDR} />
    </View>
  );
}
```

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
