### PR TITLE
fix: remove usage of deprecated UIGraphicsBeginImageContextWithOptions

### DIFF
--- a/RNSVG.podspec
+++ b/RNSVG.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license          = package['license']
   s.homepage         = package['homepage']
   s.authors          = 'Horcrux Chen'
-  s.platforms        = { :ios => "9.0", :tvos => "9.2" }
+  s.platforms        = { :ios => "10.0", :tvos => "9.2" }
   s.source           = { :git => 'https://github.com/react-native-community/react-native-svg.git', :tag => "v#{s.version}" }
   s.source_files     = 'ios/**/*.{h,m}'
   s.requires_arc     = true

--- a/ios/Elements/RNSVGSvgView.h
+++ b/ios/Elements/RNSVGSvgView.h
@@ -50,9 +50,7 @@
 
 - (RNSVGNode *)getDefinedMask:(NSString *)maskName;
 
-- (NSString *)getDataURL;
-
-- (NSString *)getDataURLwithBounds:(CGRect)bounds;
+- (NSString *)getDataURLWithBounds:(CGRect)bounds;
 
 - (CGRect)getContextBounds;
 

--- a/ios/Elements/RNSVGSvgView.m
+++ b/ios/Elements/RNSVGSvgView.m
@@ -253,29 +253,19 @@
     return nil;
 }
 
-- (NSString *)getDataURL
+- (NSString *)getDataURLWithBounds:(CGRect)bounds
 {
-    UIGraphicsBeginImageContextWithOptions(_boundingBox.size, NO, 0);
-    [self clearChildCache];
-    [self drawRect:_boundingBox];
-    [self clearChildCache];
-    [self invalidate];
-    NSData *imageData = UIImagePNGRepresentation(UIGraphicsGetImageFromCurrentImageContext());
-    NSString *base64 = [imageData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-    UIGraphicsEndImageContext();
-    return base64;
-}
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:bounds.size];
 
-- (NSString *)getDataURLwithBounds:(CGRect)bounds
-{
-    UIGraphicsBeginImageContextWithOptions(bounds.size, NO, 0);
-    [self clearChildCache];
-    [self drawRect:bounds];
-    [self clearChildCache];
-    [self invalidate];
-    NSData *imageData = UIImagePNGRepresentation(UIGraphicsGetImageFromCurrentImageContext());
+    UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
+      [self clearChildCache];
+      [self drawRect:bounds];
+      [self clearChildCache];
+      [self invalidate];
+    }];
+
+    NSData *imageData = UIImagePNGRepresentation(image);
     NSString *base64 = [imageData base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-    UIGraphicsEndImageContext();
     return base64;
 }
 

--- a/ios/RNSVGNode.m
+++ b/ios/RNSVGNode.m
@@ -296,14 +296,14 @@ CGFloat const RNSVG_DEFAULT_FONT_SIZE = 12;
             CGRect bounds = CGContextGetClipBoundingBox(context);
             CGSize size = bounds.size;
 
-            UIGraphicsBeginImageContextWithOptions(size, NO, 0.0);
-            CGContextRef newContext = UIGraphicsGetCurrentContext();
-            CGContextTranslateCTM(newContext, 0.0, size.height);
-            CGContextScaleCTM(newContext, 1.0, -1.0);
-
-            [_clipNode renderLayerTo:newContext rect:bounds];
-            _clipMask = CGBitmapContextCreateImage(newContext);
-            UIGraphicsEndImageContext();
+            UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
+            UIImage *image = [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
+                CGContextRef newContext = rendererContext.CGContext;
+                CGContextTranslateCTM(newContext, 0.0, size.height);
+                CGContextScaleCTM(newContext, 1.0, -1.0);
+                [_clipNode renderLayerTo:newContext rect:bounds];
+            }];
+            _clipMask = CGImageRetain(image.CGImage);
         }
     }
 

--- a/ios/RNSVGRenderable.m
+++ b/ios/RNSVGRenderable.m
@@ -242,35 +242,29 @@ UInt32 saturate(CGFloat value) {
         CGContextRelease(bcontext);
         free(pixels);
 
-        // Render content of current SVG Renderable to image
-        UIGraphicsBeginImageContextWithOptions(boundsSize, NO, 0.0);
-        CGContextRef newContext = UIGraphicsGetCurrentContext();
-        CGContextTranslateCTM(newContext, 0.0, height);
-        CGContextScaleCTM(newContext, 1.0, -1.0);
-        [self renderLayerTo:newContext rect:rect];
-        CGImageRef contentImage = CGBitmapContextCreateImage(newContext);
-        UIGraphicsEndImageContext();
+        UIGraphicsImageRendererFormat *format = [UIGraphicsImageRendererFormat defaultFormat];
+        UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:boundsSize format:format];
+
+        // Get the content image
+        UIImage *contentImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
+          CGContextTranslateCTM(rendererContext.CGContext, 0.0, height);
+          CGContextScaleCTM(rendererContext.CGContext, 1.0, -1.0);
+          [self renderLayerTo:rendererContext.CGContext rect:rect];
+        }];
 
         // Blend current element and mask
-        UIGraphicsBeginImageContextWithOptions(boundsSize, NO, 0.0);
-        newContext = UIGraphicsGetCurrentContext();
-        CGContextTranslateCTM(newContext, 0.0, height);
-        CGContextScaleCTM(newContext, 1.0, -1.0);
-
-        CGContextSetBlendMode(newContext, kCGBlendModeCopy);
-        CGContextDrawImage(newContext, drawBounds, maskImage);
-        CGImageRelease(maskImage);
-
-        CGContextSetBlendMode(newContext, kCGBlendModeSourceIn);
-        CGContextDrawImage(newContext, drawBounds, contentImage);
-        CGImageRelease(contentImage);
-
-        CGImageRef blendedImage = CGBitmapContextCreateImage(newContext);
-        UIGraphicsEndImageContext();
+        UIImage *blendedImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
+          CGContextSetBlendMode(rendererContext.CGContext, kCGBlendModeCopy);
+          CGContextDrawImage(rendererContext.CGContext, drawBounds, maskImage);
+          CGContextSetBlendMode(rendererContext.CGContext, kCGBlendModeSourceIn);
+          CGContextDrawImage(rendererContext.CGContext, drawBounds, contentImage.CGImage);
+        }];
 
         // Render blended result into current render context
-        CGContextDrawImage(context, drawBounds, blendedImage);
-        CGImageRelease(blendedImage);
+        [blendedImage drawInRect:drawBounds];
+
+        // Render blended result into current render context
+        CGImageRelease(maskImage);
     } else {
         [self renderLayerTo:context rect:rect];
     }

--- a/ios/ViewManagers/RNSVGSvgViewManager.m
+++ b/ios/ViewManagers/RNSVGSvgViewManager.m
@@ -46,7 +46,7 @@ RCT_CUSTOM_VIEW_PROPERTY(color, id, RNSVGSvgView)
         if ([view isKindOfClass:[RNSVGSvgView class]]) {
             RNSVGSvgView *svg = view;
             if (options == nil) {
-                b64 = [svg getDataURL];
+                b64 = [svg getDataURLWithBounds:svg.boundingBox];
             } else {
                 id width = [options objectForKey:@"width"];
                 id height = [options objectForKey:@"height"];
@@ -61,7 +61,7 @@ RCT_CUSTOM_VIEW_PROPERTY(color, id, RNSVGSvgView)
                 NSInteger hi = (NSInteger)[h intValue];
 
                 CGRect bounds = CGRectMake(0, 0, wi, hi);
-                b64 = [svg getDataURLwithBounds:bounds];
+                b64 = [svg getDataURLWithBounds:bounds];
             }
         } else {
             RCTLogError(@"Invalid svg returned frin registry, expecting RNSVGSvgView, got: %@", view);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

port of https://github.com/software-mansion/react-native-svg/commit/f5503e2c9b1b53cce3c190fa633cb376901aeb08 , plus 1 more usage we had in `ios/RNSVGNode.m`

Remove usage of deprecated `UIGraphicsBeginImageContextWithOptions` as it was causing some crashes

## Test Plan

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added documentation in `README.md`
- [ ] I updated the typed files (typescript)
- [ ] I added a test for the API in the `__tests__` folder
