### PR TITLE
feat: add svg-safe validation to xml parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.8.5-exodus.7",
+    "version": "9.8.5-exodus.8",
     "name": "@exodus/react-native-svg",
     "description": "SVG library for react-native",
     "homepage": "https://github.com/ExodusMovement/react-native-svg",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
         "react": "*",
         "react-native": ">=0.50.0"
     },
-    "dependencies": {},
+    "dependencies": {
+        "@exodus/svg-safe": "^1.0.0-rc.2"
+    },
     "devDependencies": {
         "@react-native-community/eslint-config": "^0.0.5",
         "babel-eslint": "^10.0.3",

--- a/xml.js
+++ b/xml.js
@@ -337,7 +337,7 @@ export function parse(source) {
   let root = null;
   let stack = [];
   if (source){
-    cleanupSVG(source)
+    source = cleanupSVG(source)
   }
 
   function error(message) {

--- a/xml.js
+++ b/xml.js
@@ -21,7 +21,7 @@ import Stop from './elements/Stop';
 import ClipPath from './elements/ClipPath';
 import Pattern from './elements/Pattern';
 import Mask from './elements/Mask';
-
+import { cleanup as cleanupSVG } from '@exodus/svg-safe'
 export const tags = {
   svg: Svg,
   circle: Circle,
@@ -336,6 +336,9 @@ export function parse(source) {
   let children = null;
   let root = null;
   let stack = [];
+  if (source){
+    cleanupSVG(source)
+  }
 
   function error(message) {
     const { line, column, snippet } = locate(source, i);

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,11 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@exodus/svg-safe@^1.0.0-rc.2":
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@exodus/svg-safe/-/svg-safe-1.0.0-rc.2.tgz#6cdc8f49ff375e14b9abc354936b05ab62cd1f8e"
+  integrity sha512-fSqK61HZmB6+CfKtXABC0D6re1j5eY+D3QrAoJpyKjTZ3cs9DvUYJg+Q4Gk2VSd+HLS6k1q6OYhXnaxKLzRB0g==
+
 "@react-native-community/eslint-config@^0.0.5":
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-config/-/eslint-config-0.0.5.tgz#584f6493258202a57efc22e7be66966e43832795"


### PR DESCRIPTION
Requested [here](https://github.com/ExodusMovement/exodus-mobile/pull/25043#pullrequestreview-2720806806), it adds svg cleanup+validation to the xml parsing operation.

Note that the platform is already doing this validation, but this is an extra security measure.


## Test Plan
- [x] SVG with valid XML is shown
- [x] SVG with no safe XML is rejected 


Safe example, base64 in images is ok

````
const xml='<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><image href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAsTAAALEwEAmpwYAAAecUlEQVR4nN2aB3hVZbrvv1V2zU4vBFQEBUR6EQSkBpIgLRB6Uxzx2B3vOffo9cycOeqcOXPKOOOMDaUFFAsihPRCOqCI0pKQXbITEjoYqpSQ7P27z7dWaOoozDhzZ+77PO+z1t577bXX+3/b//2+LcRfUXw5ItadJV6uL9Q31hUqjbV5GnX5dirXi6+qM0SRN1v/7/pM0V38/yK7PxGLawtU6jcJ6gsU6vIEtdmCfQUKjZtU6vOF8V59gWDHxzqebI26XM28Jl83tC5P/Y34e5LKDZaHd34sqN6osWudSuVGQV2Bzr5NGvsKBHW5Kg2FCg2FggPFunEuDfZkKXz+nkJ9gY19BTr+HJWGAgv1eVobWCq+THWN+FuVnR9qiz9fI9j2nmD3JxqVG1SqN9qp2qDizhLsK1LYXyRBUNlfpBqel68bCqVxCvV5Ak+mjV1rBfX5MhJUQ/05Co2FJngSGO9GFXemyBZ/K7IrXWd3uqAqS6UqXaNqo0ZVusqedMHutSpVGwXubIE/L5yGIpsR7vvzrRyWx1zBvlzBwXwrB0rs7C+JZF9JNNVZmnFtXa4db7pOZbpipENjgQP/JoW6fI2GfBV3hoZvrSv2/4nhNRliReUGQeUGhep0jb0ZOjWZOjVZGtUZCtUZMq/l5zHs3mChaqOVhjyd+k0hHP/SxZ6S9uSvvp1f/zSOWcMVRnYV9IoU3BUu6BkpGBgvmDta5bfPx1CTH0NNrob7E43G3BB8uSqN+TKVVGqLVKpztVN/VeOr0hXDs9LI6nTB3nQFAwzp9fUyBaTnddzrdTOvC6P4cl0MLy2O4u5QwZ2RCv3aa/Rqr9Oro4u7O4bR9RaVTnEaHSJtxIdpdAhXuSPGxt3tbfS73UYnp+DlR2/F/6nViIiGwgiOlIazT4Ka5aA2Q2FPloj8ixu/42MHO9ZZ2Z1uY+d6B1+sC2dXegw7N4awN1M1QKjcoLM33YGnpBPPTo+hW6igbwcLPTsJunUW3BqrEh9hJ9qpE+PUaReiE+eKJS40hNhwQUyEIDZS0C5cEBemEGJxYdcF7SMs3BYqmDQkljBdYBGCTlEqq353G/WfxrBrg5O/qPEFbymUrBVsS4sh9w+30bFLOEJYUYRKpwg7a1+5jb0ZGt6SjozuFUm3OIWet9no3MFOXISFmFAb0S6dmFCNmFB5tFyvYRai5VFec1mv+Tw6VMOmCLrHO+jbTrDxlak8ltIVXQhpODuL+lKXZ6Eu13bXj278jvcVdq+zc6g0kvhwDSE0om0qT8y6k6d/0p8op2q8N7yfnZ6R8dweK2gXphMXZiUmxEqsSxp/2Rjt28bfgMbKe4VZERaFMLuN3uGCi9vu5+vyiTwxpQu6CKO2+Hb2rtfw5OkjfjTjq2Ulz7Tw+ToTaannP02hKX8EJ7Lu5syGMZwrm8j8cd3pEmElLkQlPEIQEWYhKlwjJkwj2qXgUMWfBYChLitxEVY0hyBEKHS1CL7eksKh9O5MGhHL+GGRFC+TdSiEz98XPf9s43dlSvZmYW+eYGf6KMN4/LP5asN4juT14KuNYzhTMZqecYJbIuxEhatEhCvEuGKJCbUSG+LErkjDQ9uOfyYAoVaiwjTah+q4LDoOi4VJQ+yczhhBc+Ui4/n2b49hzwYn1ZkRbF0rHH+y8YdLFRpLBPVFKr4cu+n5L/83xwuGcjxzGA0Z3XFvmEsHm6Bd5HeFrIWoUAeqEMRHW9EVQVSo9XsNbBdhJ9KpXn+fUM1QeR5mU4k17mElNsxOqMOC3aay5OkBHFg/yHjGPcX9qf7YQtU6ld0fa+xZK3rftPH7ixxUplv4/GOVqvUWzngTEEKnKW8U+7OHcDJrCL78RDpH6EToToYP6kjclSLXVrRcGqEOnWhXCNHhwgAiKtT2g3keH+kwwJPnsWE6sW21I8plxSoUokLkPS1EOi2E2qLRQmVaWglWLkYIG1X5ffHmWGjMsLOv0IonW9anm5Atq8QfSpYplC7XKFoZzpYlDnLW3m2g+9WGBA7mDKBl22LaO+QDakSECmZOGo9TE9d4zwQixCZrQCgdYm03BECUS+e+e3oSZhOEWgQRdpk2VqJDbcZ3I8PM78eG2WgX4cBlcRAeLnCoFn71/ATjGc/t6G4w08YsFX+BwJcr8OYYtevGZNNyheKVGqVpCsWrBGUrreS829O4+YmcMRzKHsztNkFEeCixTiftnE6GDOzM5HEJtI8MJTrMbra8MIVolw2HEIzo3xWHZiU2QqaFCVD0FbUb7c9ogWFWetzZnl7dOuDSBQO6dyEqTCcqIsT4/QiXk7goO1FOjTCragAW63IQHWpFFw46xznZl2vHt8lCbabAm63jzbK1zST6mB80vmCpCBQvVylaJiheLihbZaFstcqu/NsRwsKJzyeQ9vxgosIEsXYHsaGCaFnpQ5y4hKBLjBObENiFilNT0FSza3Tq04XwSBcWXSPO5TQ8Kvu6qRKAq4BEOBQmjh3E6KHdiTMKXiSaELjsKvHhRjgb34kJNYuuvEdcuBOnrlO3awR7PrIgJ9K9G8MN73ty5HRqRsIPA/COTulKlbJVKiUrBXlpGuUrdcrTVCwWhfdef5A4oRMZJYh1uIxcjIsOJ1wImvY+CAefgoOLYd8c8D0AjYug6QX25M4jXBNomhW7UyXOZTeiQ4ayjAYj18Nk2ujERyoGsN0630Lv7l0RqsBht2OzmIVYt2gMHXQ3iWMGEOYy34tvI1er/6s/tTkCb6aLz9aoVEpavkHBl62xb5Pl+wHIfMM6v3i5TvlqjbJVCmWrBKVpguIVdsqXutic3psIh512oS6iIwSR4Tp2xc7wu0IJ1C0E93yoSoWa8bB3HBfrJ3DJn0qzZw4B7xyon8dnGx40HtiqCxxWBZdNJ8xpJTLUYWi404bLoeOya1gU5Qrv+Mn8BE6e3gx4ADe07iEY2AXBT4GtXDr3yZVrD37RjapMCzVZisFfKj9RqMnQ2fmRwq6P1SN/HIDXVUrSdMP4kpWKaXyaoChNo2Cpyrb1PYkOcxAtvRWqE+d0mLzg1DOc8yeCJ5WgZxpBdyoBdyq4p4NH6jSCnlTwyvOpcOxBgsdepGB1Mi890ZdZ43owekBXRvXvyqQRvXhqQW/efysZf/WLQC60rCJ47h24sA5acqG10NBgSwHB1gICzenQugT4rTEfTJveCc+7Ftz5gqqNKt5cK1UZAn+BzZhav9P4suViVq7k+ivM8C9fLVVQtKodFcsUitKEkYexYbJFmX04JlJn5uQ7CLqnEawdTdA90zz/QZ1KsOohqF5A0D0H3DMJ1M4G30LwPwqNj8LBZwkeeo5g00u0Nr0Cp14neHY5wfPvw8V10PwJweZPoPkjgs1pBC78huDXz0Pro4ZTKjNDyV5ip2ypYNsamQYWPlujsHODjap06+lvA7BSULJCo0i2vzRhACBTQHYBCcBnGXehq662FiSLlQ2brpH16lSavbPBnWh4/sYASKXFfz8ttZMJGhEyg1bvQoLeh6D2UfA/DPuehP3/BIf+1YgWTvwKTv0GzrwJ598y9cISuPgaXHyF4MWXCZ59msDxFLrEhfDUgq7s2SSoybJQvdFKdbqFqnQb29eqbF79HcWwflM4pTLnV6pUvKtSlmYCsWWpg/w0wcjekditghiXRpRLM1LBCP/9sznvnwyVCwh4pt4gANOgZlZbikwFbwp45oJ3Lvjm0OJ/mNb6Jwg0PAGNTxM88Bwc+TnBY78k2PSfBM/8F8Gv/xvO/w+c+zWB878keP5f4MzjtJ59EH/RT4xn8+VGU5Mt8OUp1GSrxvrF3iyNmlwXn72vD79i/P5CMe9wuYPipdLzZheoaDvKerBzbUfjhjEuF1GWcKLjJYIOzh/6FZdk+LonGYbcqPFXQGjzvkyBoEfqbAOIoHch+BZB7WLwP0Gw4VmCB/4JDv8zHHsBmn5G8OQvCJz+OYGzPyNw7nk4+wzB04sJfj0Xzkwznre+pB01cnUqXRIhBbkM78lW5DI83mzL1VWkxnyFg+WCXeutlMqWt0pn01JBWZrGltUKW9IlB1AJ0VVC7dJ4jYbP/g/BmvvBZxY+aqb/CADMBNktPAsIeBcQ9DxA0LeYgP9xqH+SYONTcOhZOPIMwa+eJnDyKQKnniFw8mkCpxbDqUUETs2EoykG6yxc0RVvlh1fjsUAoTrdBGPvRkUCcDUNDhdpHCl3UPSOMIyXhkvvSzK0eaXCy8+3w2YLwaEL7oizwrnnaPYm0VI9xyxoRkjffASYNWN6GwAzroAQ9MwygAh45hP0PmDyCf9PCNQvhsbHCO5/nODhfyB4/BGCxx+GE1IfhJPzCB6bQmvTLAbfYeNnD97DnnWm0VIlG6xOV6nJkMdr6sChYkH1BjsVK2xGB5AASC1fpVHxts7wwbHoVrkIIvjaqPTzaDEefBLUSONlm5t8BYzvrf7uaVyqnAiH58OpJ6FO3mdOGwAmCMgW6p3VFgmyNswn4F1IoG4+BP6DM96nIfgygQML4fADBA4vJNg0h2DTDFqPTqLlxDyee3goyX16UZtrx5Mt1zMkJ7AZvMCTpV+Ogn7iWIlwHSmzUCKp7wpJfaWaBVBGQP6qSDq2EwirnZ8/MJiAewbBmhmm190pN+HtyVD1CC37JvPUTHOuMJfTBFx4hID0vHcquGeZ7dQ7g4ABwDxwP0Br7XQ4++8IoaAqZhr26RwDRxcTkGAenUXw2HRomAIHJvL+L1OJj7JSnWGjNk/gy9HYm2mmgawBu4zNG/U1caRM/Ky2wMHmtrZXvkoxWmDFuxrFyxW2vmdyb3Mh5AFaa1KNvDVCt+ZG2940AvL6uknGfRQ9zBitjXPFPHLgIYKeFHDPhppFtO6dT8AzndbqmVzyLID9k83rNZP6SrVYhLEeSNMs2J8KB+dRkjGHfj1Cef1/TSc6xkWlXJzNUg2ve3IkIzRTwp0p37MExdEKdc22982CJ4lPhUGATJURUL4squ0HNbpE6+B/yAjPoHuKGfo3k/Oe+43uIe+XnbWaeXPnY9GlQSqc/hlBzxTzOm8KWzZMZMmrSXz4yhhafCmwf/4Vwxv319Pr7oHcfls3I4poXkSgYSatB+Qssoi7u0YiFJ0Bt7XDk+/Ak6FQk2XFm6exe525bL/jI7mcL5rF8Qq1qmiFQsW7FiP0KyTxWaUao3DJcsG2FZrBAC3CaVTWQI2sAdNp9aTSatDeG42AFPAvQKgqmiawKaFoioJTt5kA1E+lZa9MK0mhZzFp6K2IEIXO4Taa65OhagwTh9+KatWMtHEI69XIbHqE1vppXDqcQvDAXPBPIu3lRHN839KdvSURfFUo+79GY57CwU2Co+VyN0tIABxnSyTzW2WhdKUsfCYAMgLkOFy+2kqnGHMoOfvlQoLyIb3TCXim3SQAckiaQrf2GrqIQKhRCN1iGHPp8PO0VM2jpXoKuKfQ7EmGxofZ/N7jcGQeVM7iQs3D0PS4abRirgzbNcHi6T1p9U4A31xaGifB/kQCDXNoPjieF+eZiziXPrdzYJud02VOjpQLDpUoHN9s52iF2iyOlbkulsrRd4Vu5HxZ2lUASlcolKQ5SLi3E71vj+JI+qDr2l1ADj83HP4pUD2PS/UzWfG7FAbdIXjmgX607n8aKueaRdWbCocf5tKeiXD8GdO7xx6D1hco+2ASF3cmQNOT/PZfhjBz3O3UbX6CVtk1fJPAPRfqJ0D9fFoPjzJa54VtA417ZLzTjQubXBz6UnB8s+BoqeB4uUVGQbM4XOTyy9ZXtEzqVQBkOpSnaez5SG5+CNjxAE1bRhq5HzSqvzT+JgComUFr7SiC7oVcqhpPs3sqrZVTwDuTr+vGGkSqPieJP/xiHOHGHoMg86NCrK5oo/5w8gV2FN4HnilckvfzpXChejwBdzItnrlmkfUl09I4EfbNIlg3lVbfHPauediMgu02jlTYOF6hc7xC5Xi5ypFypVkcKAjbKPt9yQoFuRJUKsfglRajDZauVtn4Tm/jBk2FSVz4NPlPIDvfJD6XI2jq1bHZl0ptfgL1BeMI1Mzjf55N4vlxw5kYHUHpL39BbdVztOydgifzfvblTjXCPWhQ7+kEDQbaRsbkuO2fBvumQn0K1KZC2UTz+T+/hWObBV9tVg01QKhQm8WhoohfyoInmZ8EoGCJoHSFndKVci1AZdqwu5l8760czulP6477/0wArtXpBD2TwD+Pupyx+PPG480ex5kd0/jp9M70i1ZJ6BrKonHxvLToTg6Xj8WbO5q6rBQOFCe3MUVp+NWUNAConUpQGl+fQtA3leMbB3NrjIXMt4ZyYpsJwPEKhWPligSgRRwqjOwo6a8EIO8tuQAqmaDF4APFK8LQhJ38FVNoyhpK8+fjfjwAaqZyqXI2tTkJ+PIS8OYkteloAnumM31INFZhMdYZT1eNojF/PHvzE/HnjMaXm0ht3hhjcjQXYORcIflJqtFCJQBB/ySon8HujYN5cuIdzBwbwcnN1isRIAE4WtH2jxODAK2WKSBbn3INIYozwqfqg0kcyxzBieIRbcXP7AA/3AVSrtGpRrgive6ezPnqedTmjcOb26Y5V9WdNx5/3hgaCsdRLcHJTjKiw5srzxPN63LH4pMg1M6l1ZNCoEaySDmYTQX/RGhI5eSX4/GvG8pP53UldXQIJyvs16SAwldbtakGAKWX6e9KnZJlqtESy9+VoEQYAHyxZgZHswdxPGv4NR3g5tqg4SUJhG8mTdsm4M4egy/vstFJ1wEgPXzt8bu0Ni8RX54EYSRnd8ouM9tkp94ZUJfK0U/H0VA2nso1/Zg65laeTo2jaYuFpi2aoRIEcVkuL4TIvl+RZqV4udVghSWrLLQL01j+0iQO5w7kxIZRxgh7LQg3DsBUI0TrCkbjzpMGj73GoOsB+GG9er0vL5G6wmTqCsdwtGwch7aM40D5WPaVJOEvnsCWFXdxV3sL2W+O4PRnpuESgBNbr1kbLF4hfmFSYel9SYZsJgCrdZ6YeSdD7nBS+X4vTmTJhc/pBPfe6Og7vc0rM2mtnkpt7ihq85Lw5V82Quof9/L3A2B+z5ObiCd/HLUFEghT/UVJ+IoT8Zcm4stNNvYpju3qyPFycSUCrgNASpGR+5epsKBcssOVgu0fmjygbvVYNi/rysni+8EvFzFTjEJmjsKpBih4ZK5PIdA2I+CbzdkvpdeTqcufgD8v+XvD+k9TeT9paCK1+Ym4CxPxbRqCu2gMvowh5L+VavKYLWEGG7wMQNNmbbG4Vkpk/q80SZDBBNMkEVKo+EBWY5XctydQtTyBbW/35VDxRBoKx3C4NJGz2yfTunc2gZo5tHhmc35PKkc3J7G/aCQNBWNpKEqmYdMEI9/lQ/6lALhcGGtzk3EXJLMvL4ldb3czvL/85b4GB5Ak6HIRFN+UwiXiDVkHZP+/XBSN/YG0cF5/UbIxQdWaEXyxvA9fruxLw6YE9hWOpWFTEo3FyYYeKE7iQPF4GguTaShMor5gvKHSM3InWYb/j2v8twHw5w2nJjeBmnUj+OAlc7uc6hCObHXw9VbF8P6x8j+yRVayXDPorwRCMkOpX6Qp5C2NJmFQB+KEYPNrfdj+9hA+TRuALz/JME6GuN8wOJH6gmRD6/LH4y8Yg79gLJ68RNy5Sd/j/cRvFMXv+jyh7fyPX+fLHYsnazx7P0kg4z+GG6Ny874YmrZGc3q74Fh5xHd7/7IULtE+knsDxctNlYSo4n1B+dIOFH0QZey6rHt1AtvfvIUv3hjO9pV9OFQ0BX/+RLyFSfgLEvEXmKBcq0b4X2l5plYbhXAcNXljDDJUl5mEN2sC3twx+L5hWE3uBNz5Y6nJmURN1ozrPnNnT8Kbk4w3bzTurASqPxlO4WvDjInx3N77OP1ZFEcrFJq2yt6vGf1ffJ/kvCEofFtl0xKN3DcE+W/Fm1tkyxxsW387DqHyb4vvpXppf3asGMAXy3tSXzjNqLbevITrDP6myhC9rHU5I6nMn4A3fyxHtzyCJ2ss/txEavLGXuPty8RoLO7sKXjzhlKbPx6fLHqXVQKWlWTMCe7s0fwkqauxbHZxd18Ob3ZwQvb8LWb1P7HFyv6tIup7ASh4R0OCkP+WBEIhU56/YadMbpmtsOLelGzkVXuH/NfnIkqX9OXTt+7Ck550Q4ZL9eSOpSFrNL6CyXy50szTz7OeoMagxPd/ixnWZcnwHkND8UO4N02kVno8S0ZMEvXGbwynfssieka1bdYcGsbRrTbOb9FN0rNFcOJTwcnPfsD7Uja9LqILlmkUr9QpluRI7g8uFRS85qJwhaD0XcHTC+ag6DHYRRgp90ZSu3EOFW/2Y8vSvvgLEvAWjaOyYCLe3FFGSHvzR+LOH051/mjq8qWnU/lyZQ/cmTN4+ZHuhEZYcNp01vwhhYa8GTRmJePLTKAuJ4GazFH4chL4yvcvhnGlHz6ML2O08bknay4//4c7iVbMv98k3evgWEUYJ0qdnCpWOLklkqatEgCZAgpNn6orxI3IhlfFsbwlqrEjvOntOEqXOSlbLchb6mRw576EORIRak90S2esajzhFkE7XfDywm5Ur5+C++MRuFcOYueHw6hcOxRPegK+9GQOZI/ms1UTeH5eR6Ls5szf5fauNF9oQYrTaS5zjRrYgccW9eSZB3swts8tOC8vguoWw1BVFShCQyixKNZILI674NhPOVwk2F8sqC8VHNzs5PinV8ffbxGfH5L1vxPkvm0l/TVB1is6G34XRdp/DiUydAJ2tTcW5V5U9V6EOgCh9kNovVD0rmhWK5qxbC3/xyeMaU4eZT9W5PuaC2d0OGfOnjaMDgQuEOSMcd4aDDJx8mRe/9U4pozpSN/eA/j967/n1Bnz2tWr3iUu+h9xiH7EucZjF0Nxir4I5S4iw1+gOG0UjRkxeLJ1Dkuvl4SYQ89mFRDKTQGQ9aaI/Pg3guwlKtmvh1HwyUjiXY+hqT3R1P7o4j40vTOa0gtd3IOu9MEpumLT7sCudcWq3oWmDyXEOQXdMgZdG4RF9MIuhtFy4SxOm9MwKhg0tSXQbLxe8/ZDnN8uKfc/mvncdo2UxHFT0K33IvTeCOUebum0CKENJUSMwq60o0P885z2J7PnY8HhHJ0DRbox9h4rU39/U8ZfK+tfdZG9NIn4+MdRRV80pT+a0q/t2Kft/Frt26YD0MUgIl3zULTeKOpANDEcqyWRxv1HDIN69+7D9u1f0NJiGi8NXjAxmuDuOXB8pvH6vpHDjM8cIYLU8b9G13qiqvcgpOfFfdzSbrbxXLoqf3sg8ZELqS5L5EiOk8bNgiPl36C8Nytr37i1S6RDrsl3xyIGfofBf0x7cUv8IwjRH02Tf2geiqZ1Nx68b49HgRZaWi/w+1d/z/PPvXDF2/IYlNttZ/6Z+XMeIkjwms+GIUQfhLib9nHzCLHNRNfNZ9JV0zG60he7I5UWzwhOloZkih9DdFfCSFUMQ1d73QQA/QkNG8dt7R5DFcOx6HejaN0NTwkxpi20g1y8eA6/t56Lzc0EAy2MvO9+uPgi05LvNK/hPEEukZG+A6t1OJpMI8sU2sUsQsjnkZF1ze+qlgGoojeKGFEiflSxdO2nGmF24xFgU4ahaV1wuabSPu5ZFNELqxiC3T6YY0f3SesIBlugFZqDAVounaK5+SCbP5rGPfeMprm1xQDF9H4CQu+BzTBSrvcPptOtMi0vp6SpitYNTRm8XvxlZKZ24wD0MzwhlAGEuu7HaUtBiAGoSk9UcS+DBj5JICBd3EwwKE+uyuWQD0iEAq18deIcofZUNO0uo7ZYbP2ICJuMJpIMoK//zQGPir+s9O9xYwD0MQDQtEG4bLIQ9kRV+mLRe2PR+qOKiW0hfu5Klf8WAMELxjHcOdfIe5lWqir3A4cQH/0Aqtbv+hRQ+70t/lqi3QgIqqz+g4iLWYCQrVIWKtXsHE77JE6dNkKAoMyBbwAQbJWfmACEWWegaZc9PZAO7RYixL0oWg9UZYDxvhBCFX9t0UX/Ud/dAq+2SVXpbxjfscPjKEa+Dmh7rzf3DFhIINhKIHDpOgA6d+1IoFUmQDP39H8SRfRAUwYZIChiOOGuFBSlL6o6AE3t+6H4WxBN6XfmKke4PgosmuzbA4mPW2C8VmUUqD0JtU8y0yBwfQ68t+YDIzKk2PRJ6MZ9pPEDuLXdQ1i0e2U7jBN/i6IpAy6ahstQl+EpvSQN7oWuJiGEGSmK0htVGcySN/O5dMkkQpdl/ScbaQm0MGvGv6OKgViVIahqd6zaWGQhFn8Pout9xmpqj4smCGYkqHp/gxxpQs4PfRC6/KvM+OsrIPDiv/5bWy2Ygqp1wSL6Py3+3kWX9ULtu8yiDCPCmYpulR1iIBbLSN77oJRga5DW4Clpd3q3Tn0e/Gs92P8FPSR9QB5xQLIAAAAASUVORK5CYII=" width="64" height="64" /></svg>'
````

Unsafe example, we don't want urls in href at all

````
const xml='<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64"><image href="https://assets.coingecko.com/coins/images/1/thumb/bitcoin.png" width="64" height="64" /></svg>'
`
````

<img width="377" alt="Screenshot 2025-03-27 at 9 04 16 AM" src="https://github.com/user-attachments/assets/d8c879e0-18b9-4aee-a10c-dc6cb2133738" />
