### PR TITLE
feat: upgrade @exodus/svg-safe to ^2.0.0 with trusted option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "9.8.5-exodus.11",
+    "version": "9.8.5-exodus.12",
     "name": "@exodus/react-native-svg",
     "description": "SVG library for react-native",
     "homepage": "https://github.com/ExodusMovement/react-native-svg",
@@ -29,7 +29,7 @@
         "react-native": ">=0.50.0"
     },
     "dependencies": {
-        "@exodus/svg-safe": "^1.0.0-rc.2"
+        "@exodus/svg-safe": "^2.0.0"
     },
     "devDependencies": {
         "@react-native-community/eslint-config": "^0.0.5",

--- a/xml.js
+++ b/xml.js
@@ -21,7 +21,7 @@ import Stop from './elements/Stop';
 import ClipPath from './elements/ClipPath';
 import Pattern from './elements/Pattern';
 import Mask from './elements/Mask';
-import { validate as validateSVG } from '@exodus/svg-safe';
+import { validate as validateSVG, validateTrusted as validateSVGTrusted } from '@exodus/svg-safe';
 export const tags = {
   svg: Svg,
   circle: Circle,
@@ -180,8 +180,8 @@ export function SvgAst({ ast, override }) {
 }
 
 export function SvgXml(props) {
-  const { xml, override } = props;
-  const ast = useMemo(() => xml && parse(xml), [xml]);
+  const { xml, override, trusted } = props;
+  const ast = useMemo(() => xml && parse(xml, { trusted }), [xml, trusted]);
   return (ast && <SvgAst ast={ast} override={override || props} />) || null;
 }
 
@@ -193,14 +193,14 @@ async function fetchText(uri) {
 const err = console.error.bind(console);
 
 export function SvgUri(props) {
-  const { uri } = props;
+  const { uri, trusted } = props;
   const [xml, setXml] = useState();
   useEffect(() => {
     fetchText(uri)
       .then(setXml)
       .catch(err);
   }, [uri]);
-  return (xml && <SvgXml xml={xml} override={sanitizeProps(props)} />) || null;
+  return (xml && <SvgXml xml={xml} override={sanitizeProps(props)} trusted={trusted} />) || null;
 }
 
 // Extending Component is required for Animated support.
@@ -211,14 +211,15 @@ export class SvgFromXml extends Component {
     this.parse(this.props.xml);
   }
   componentDidUpdate(prevProps) {
-    const { xml } = this.props;
-    if (xml !== prevProps.xml) {
+    const { xml, trusted } = this.props;
+    if (xml !== prevProps.xml || trusted !== prevProps.trusted) {
       this.parse(xml);
     }
   }
   parse(xml) {
     try {
-      this.setState({ ast: parse(xml) });
+      const { trusted } = this.props;
+      this.setState({ ast: parse(xml, { trusted }) });
     } catch (e) {
       console.error(e);
     }
@@ -255,7 +256,7 @@ export class SvgFromUri extends Component {
       props,
       state: { xml },
     } = this;
-    return xml ? <SvgFromXml xml={xml} override={props} /> : null;
+    return xml ? <SvgFromXml xml={xml} override={props} trusted={props.trusted} /> : null;
   }
 }
 
@@ -329,7 +330,7 @@ const validNameCharacters = /[a-zA-Z0-9:_-]/;
 const whitespace = /[\s\t\r\n]/;
 const quotemarks = /['"]/;
 
-export function parse(source) {
+export function parse(source, { trusted = false } = {}) {
   const length = source.length;
   let currentElement = null;
   let state = metadata;
@@ -337,7 +338,8 @@ export function parse(source) {
   let root = null;
   let stack = [];
   try {
-    validateSVG(source);
+    const validator = trusted ? validateSVGTrusted : validateSVG;
+    validator(source);
   } catch (e) {
     console.error(`SVG XML is not svg-safe!!!. Error: ${e.message}`, e);
     return undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,10 +90,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@exodus/svg-safe@^1.0.0-rc.2":
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@exodus/svg-safe/-/svg-safe-1.0.0-rc.2.tgz#6cdc8f49ff375e14b9abc354936b05ab62cd1f8e"
-  integrity sha512-fSqK61HZmB6+CfKtXABC0D6re1j5eY+D3QrAoJpyKjTZ3cs9DvUYJg+Q4Gk2VSd+HLS6k1q6OYhXnaxKLzRB0g==
+"@exodus/svg-safe@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@exodus/svg-safe/-/svg-safe-2.0.0.tgz#8ad7d4cbef79514c06f8c90f2af420a60ac746e7"
+  integrity sha512-SDt4Z9opQUKVYU0+UeWTz5naEkjkUGv/xsOqcaSvvN4xEe9KcZ2p8msKNge6/IQy6RdJVW/C95RqIj34CfgFrg==
 
 "@react-native-community/eslint-config@^0.0.5":
   version "0.0.5"


### PR DESCRIPTION
## Summary

Required for https://github.com/ExodusMovement/exodus-mobile/pull/38732

- Bump `@exodus/svg-safe` from `^1.0.0-rc.2` to `^2.0.0`
- Add `trusted` prop to `SvgXml`, `SvgUri`, `SvgFromXml`, `SvgFromUri` components
- Add `trusted` option to `parse()` function
- When `trusted: true`, uses `validateTrusted` for less strict validation (for trusted internal SVG sources)
- Bump version to `9.8.5-exodus.12`

## Usage
```jsx
// For trusted SVGs (internal icon storage, CTR database)
<SvgXml xml={xml} trusted />

// For untrusted SVGs (external sources) - default behavior
<SvgXml xml={xml} />
```

## Changes
- `package.json`: Version bump and svg-safe dependency update
- `xml.js`: Added trusted prop forwarding and validator selection
- `package-lock.json`: Updated lockfile